### PR TITLE
Unexpected token error on line 88

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -85,19 +85,19 @@ Elixir.extend('browserify', function(src, output, baseDir, options) {
 function browserifyStream(data) {
     var stream = browserify(data.paths.src.path, data.options);
 
-    config.js.browserify.transformers.forEach(transformer => {
+    config.js.browserify.transformers.forEach(function(transformer) {
         stream.transform(
             require(transformer.name), transformer.options || {}
         );
     });
 
-    config.js.browserify.plugins.forEach(plugin => {
+    config.js.browserify.plugins.forEach(function(plugin) {
         stream.plugin(
             require(plugin.name), plugin.options || {}
         );
     });
 
-    config.js.browserify.externals.forEach(external => {
+    config.js.browserify.externals.forEach(function(external) {
         stream.external(external);
     });
 


### PR DESCRIPTION
When running browserify within gulp:

`mix.browserify('app.js);`

I received the following error:

```
node_modules/laravel-elixir-browserify-official/browserify.js:88
    config.js.browserify.transformers.forEach(transformer => {
                                                          ^^
SyntaxError: Unexpected token =>
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (gulpfile.js:6:1)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
```

I tried googling for a solution, but it seems this was only happening recently.
https://laracasts.com/discuss/channels/elixir/elixir-browserify-issues/replies/172994

Wrapping `function` around it seemed to fix it.
